### PR TITLE
Add the ability to append to the current selection when recall

### DIFF
--- a/mark_and_move.py
+++ b/mark_and_move.py
@@ -194,12 +194,14 @@ class MarkAndMoveSaveCommand(sublime_plugin.TextCommand):
 
 
 class MarkAndMoveRecallCommand(sublime_plugin.TextCommand):
-    def run(self, edit, clear=False):
+    def run(self, edit, clear=False, append=False):
         mark_and_move_marks = self.view.get_regions('mark_and_move')
         if not mark_and_move_marks:
             return
 
-        self.view.sel().clear()
+        if not append:
+            self.view.sel().clear()
+
         for region in mark_and_move_marks:
             self.view.sel().add(region)
 


### PR DESCRIPTION
Currently, the`mark_and_move_recall` already clears the current selection.

This PR adds the optional `append` argument that can be used to append all marked regions to the current selection